### PR TITLE
GUARD-2888 Remove Deactivated/Deleted Locations

### DIFF
--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -22,4 +22,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[ assembly : AssemblyVersion( "1.7.5.0" ) ]
+[ assembly : AssemblyVersion( "1.7.6.0" ) ]

--- a/src/ShopifyAccess/IShopifyService.cs
+++ b/src/ShopifyAccess/IShopifyService.cs
@@ -43,12 +43,20 @@ namespace ShopifyAccess
 		ShopifyLocations GetLocations( CancellationToken token, Mark mark = null );
 
 		/// <summary>
-		/// get locations async
+		/// Get all Shopify locations for the shop
 		/// </summary>
 		/// <param name="token">CancellationToken</param>
 		/// <param name="mark">Mark is a special tag, which help to search in logs</param>
 		/// <returns></returns>
 		Task< ShopifyLocations > GetLocationsAsync( CancellationToken token, Mark mark = null );
+
+		/// <summary>
+		/// Get active Shopify locations for the shop
+		/// </summary>
+		/// <param name="token">CancellationToken</param>
+		/// <param name="mark">Mark is a special tag, which help to search in logs</param>
+		/// <returns></returns>
+		Task< ShopifyLocations > GetActiveLocationsAsync( CancellationToken token, Mark mark = null );
 
 		/// <summary>
 		/// Get all existing products

--- a/src/ShopifyAccess/Models/Location/ShopifyLocation.cs
+++ b/src/ShopifyAccess/Models/Location/ShopifyLocation.cs
@@ -10,5 +10,8 @@ namespace ShopifyAccess.Models.Location
 
 		[ DataMember( Name = "name" ) ]
 		public string Name{ get; set; }
+
+		[ DataMember( Name = "active" ) ]
+		public bool IsActive{ get; set; }
 	}
 }

--- a/src/ShopifyAccess/ShopifyService.cs
+++ b/src/ShopifyAccess/ShopifyService.cs
@@ -106,6 +106,13 @@ namespace ShopifyAccess
 			return locations;
 		}
 
+		public async Task< ShopifyLocations > GetActiveLocationsAsync( CancellationToken token, Mark mark = null )
+		{
+			var allLocations = await this.GetLocationsAsync( token, mark ).ConfigureAwait( false );
+			var activeLocations = allLocations?.Locations?.Where( x => x.IsActive ) ?? new ShopifyLocation[] {};
+			return new ShopifyLocations( activeLocations.ToList() );
+		}
+
 		private ShopifyOrders CollectOrdersFromAllPages( string mainUpdatedOrdersEndpoint, Mark mark, CancellationToken token, int timeout )
 		{
 			var orders = new ShopifyOrders();

--- a/src/ShopifyAccessTests/ShopifyAccessTests/Locations/LocationListTests.cs
+++ b/src/ShopifyAccessTests/ShopifyAccessTests/Locations/LocationListTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading;
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using NUnit.Framework;
 using ShopifyAccess.Exceptions;
@@ -39,6 +41,15 @@ namespace ShopifyAccessTests.Locations
 
 			// Act, Assert
 			service.Invoking( s => s.GetLocations( CancellationToken.None ) ).Should().Throw< ShopifyUnauthorizedException >();
+		}
+
+		[ Test ]
+		[ Explicit ]
+		public async Task GetActiveLocationsAsync_ReturnsOnlyActiveLocations()
+		{
+			var result = await this.Service.GetActiveLocationsAsync( CancellationToken.None ).ConfigureAwait( false );
+
+			Assert.IsTrue( result.Locations.All( x => x.IsActive ) );
 		}
 	}
 }


### PR DESCRIPTION
[GUARD-2888]

**Problem**: Our Inventory Syncs can't push quantity when a deleted or deactivated Shopify location is mapped to an SV warehouse on channel accounts.

**Solution**: Added an endpoint to GetActiveLocations, in order to then remove from channel account settings in v1 Shopify locations that have been deactivated or deleted since the channel account was created.

# Type of change <!-- should only be one -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Functionality change (fix or feature that would cause existing functionality to work differently than before)
- [ ] Configuration change
- [ ] New / updated script
- [ ] Refactoring
- [ ] New tests to existing code

# PR Readiness Checklist

<!-- Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it. -->

- [ ] Followed [development conventions][1] to the best of my ability
- [ ] Code is documented, particularly public interfaces and hard-to-understand areas
- [ ] Tests are updated / added and all pass
- [ ] Performed a self-review of my own code
- [ ] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [ ] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions
