### PR TITLE
VT-6136 Shopify: Shopify quantity not matching quantity in SV

### DIFF
--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -22,4 +22,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[ assembly : AssemblyVersion( "1.8.0.0" ) ]
+[ assembly : AssemblyVersion( "1.9.0.0" ) ]

--- a/src/ShopifyAccess/Models/ProductVariant/ShopifyProductVariant.cs
+++ b/src/ShopifyAccess/Models/ProductVariant/ShopifyProductVariant.cs
@@ -19,7 +19,7 @@ namespace ShopifyAccess.Models.ProductVariant
 		{
 			get
 			{
-				if ( Enum.TryParse< InventoryManagementEnum >( RawInventoryManagement, out var inventoryManagement ) )
+				if ( Enum.TryParse< InventoryManagementEnum >( RawInventoryManagement, true, out var inventoryManagement ) )
 				{
 					return inventoryManagement;
 				}

--- a/src/ShopifyAccessTests/ShopifyAccessTests/Products/Models/ShopifyProductVariantTests.cs
+++ b/src/ShopifyAccessTests/ShopifyAccessTests/Products/Models/ShopifyProductVariantTests.cs
@@ -1,0 +1,37 @@
+using FluentAssertions;
+using NUnit.Framework;
+using ServiceStack.Text;
+using ShopifyAccess.Models.ProductVariant;
+
+namespace ShopifyAccessTests.Products.Models
+{
+	[ TestFixture ]
+	public class ShopifyProductVariantTests
+	{
+		[ Test ]
+		public void Deserialize_CorrectInventoryManagement_WhenDoesNotIgnoreCaseForEnum()
+		{
+			// Arrange
+			var json = "{\"id\":1,\"inventory_management\":\"Shopify\",\"inventory_item_id\":0,\"weight\":0,\"price\":0,\"updated_at\":\"\\/Date(-62135596800000-0000)\\/\"}";
+
+			// Act
+			var shopifyProductVariant = JsonSerializer.DeserializeFromString< ShopifyProductVariant >( json );
+
+			// Assert
+			shopifyProductVariant.InventoryManagement.Should().Be( InventoryManagementEnum.Shopify );
+		}
+
+		[ Test ]
+		public void Deserialize_CorrectInventoryManagement_WhenIgnoreCaseForEnum()
+		{
+			// Arrange
+			var json = "{\"id\":1,\"inventory_management\":\"shopify\",\"inventory_item_id\":0,\"weight\":0,\"price\":0,\"updated_at\":\"\\/Date(-62135596800000-0000)\\/\"}";
+
+			// Act
+			var shopifyProductVariant = JsonSerializer.DeserializeFromString< ShopifyProductVariant >( json );
+
+			// Assert
+			shopifyProductVariant.InventoryManagement.Should().Be( InventoryManagementEnum.Shopify );
+		}
+	}
+}

--- a/src/ShopifyAccessTests/ShopifyAccessTests/Products/Models/ShopifyProductVariantTests.cs
+++ b/src/ShopifyAccessTests/ShopifyAccessTests/Products/Models/ShopifyProductVariantTests.cs
@@ -8,9 +8,26 @@ namespace ShopifyAccessTests.Products.Models
 	[ TestFixture ]
 	public class ShopifyProductVariantTests
 	{
+		[ TestCase( "" ) ]
+		[ TestCase( null ) ]
+		[ TestCase( "Blank" ) ]
+		[ TestCase( "blank" ) ]
+		[ TestCase( "strange_status" ) ]
+		public void Deserialize_ReturnsBlankInventoryManagement( string rawInventoryManagement )
+		{
+			// Arrange
+			var json = "{\"id\":1,\"inventory_management\":\"" + rawInventoryManagement + "\",\"inventory_item_id\":0,\"weight\":0,\"price\":0,\"updated_at\":\"\\/Date(-62135596800000-0000)\\/\"}";
+
+			// Act
+			var shopifyProductVariant = JsonSerializer.DeserializeFromString< ShopifyProductVariant >( json );
+
+			// Assert
+			shopifyProductVariant.InventoryManagement.Should().Be( InventoryManagementEnum.Blank );
+		}
+
 		[ TestCase( "Shopify" ) ]
 		[ TestCase( "shopify" ) ]
-		public void Deserialize_CorrectInventoryManagement( string rawInventoryManagement )
+		public void Deserialize_ReturnsShopifyInventoryManagement( string rawInventoryManagement )
 		{
 			// Arrange
 			var json = "{\"id\":1,\"inventory_management\":\"" + rawInventoryManagement + "\",\"inventory_item_id\":0,\"weight\":0,\"price\":0,\"updated_at\":\"\\/Date(-62135596800000-0000)\\/\"}";

--- a/src/ShopifyAccessTests/ShopifyAccessTests/Products/Models/ShopifyProductVariantTests.cs
+++ b/src/ShopifyAccessTests/ShopifyAccessTests/Products/Models/ShopifyProductVariantTests.cs
@@ -8,24 +8,12 @@ namespace ShopifyAccessTests.Products.Models
 	[ TestFixture ]
 	public class ShopifyProductVariantTests
 	{
-		[ Test ]
-		public void Deserialize_CorrectInventoryManagement_WhenDoesNotIgnoreCaseForEnum()
+		[ TestCase( "Shopify" ) ]
+		[ TestCase( "shopify" ) ]
+		public void Deserialize_CorrectInventoryManagement( string rawInventoryManagement )
 		{
 			// Arrange
-			var json = "{\"id\":1,\"inventory_management\":\"Shopify\",\"inventory_item_id\":0,\"weight\":0,\"price\":0,\"updated_at\":\"\\/Date(-62135596800000-0000)\\/\"}";
-
-			// Act
-			var shopifyProductVariant = JsonSerializer.DeserializeFromString< ShopifyProductVariant >( json );
-
-			// Assert
-			shopifyProductVariant.InventoryManagement.Should().Be( InventoryManagementEnum.Shopify );
-		}
-
-		[ Test ]
-		public void Deserialize_CorrectInventoryManagement_WhenIgnoreCaseForEnum()
-		{
-			// Arrange
-			var json = "{\"id\":1,\"inventory_management\":\"shopify\",\"inventory_item_id\":0,\"weight\":0,\"price\":0,\"updated_at\":\"\\/Date(-62135596800000-0000)\\/\"}";
+			var json = "{\"id\":1,\"inventory_management\":\"" + rawInventoryManagement + "\",\"inventory_item_id\":0,\"weight\":0,\"price\":0,\"updated_at\":\"\\/Date(-62135596800000-0000)\\/\"}";
 
 			// Act
 			var shopifyProductVariant = JsonSerializer.DeserializeFromString< ShopifyProductVariant >( json );

--- a/src/ShopifyAccessTests/ShopifyAccessTests/ShopifyAccessTests.csproj
+++ b/src/ShopifyAccessTests/ShopifyAccessTests/ShopifyAccessTests.csproj
@@ -109,6 +109,7 @@
     <Compile Include="OperationTimeoutTests.cs" />
     <Compile Include="Orders\OrderMapperTests.cs" />
     <Compile Include="Orders\OrdersListTests.cs" />
+    <Compile Include="Products\Models\ShopifyProductVariantTests.cs" />
     <Compile Include="Products\ProductVariantTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\WebRequestServicesTests.cs" />


### PR DESCRIPTION
# Description

Tickets: [VT-6136]

Summary: we should add ignore case for enum

## Background

We don't have ignore case for important enum and it equals default value. So our inventory sync isn't working.

## About these changes

Add ignoreCase flag and tests

# PR Readiness Checklist

- [X] I have updated all relevant configuration
- [X] Followed [development conventions][1] to the best of my ability
- [X] Code is documented, particularly public interfaces and hard-to-understand areas
- [X] Tests are updated / added and all pass
- [X] Performed a self-review of my own code
- [X] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
- [X] Confluence documentation is updated, if needed
- [X] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions


[VT-6136]: https://agileharbor.atlassian.net/browse/VT-6136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ