### PR TITLE
VT-6137 Shopify: Orders not getting marked as shipped

### DIFF
--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -22,4 +22,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[ assembly : AssemblyVersion( "1.9.0.0" ) ]
+[ assembly : AssemblyVersion( "1.9.1.0" ) ]

--- a/src/ShopifyAccess/Models/Order/ShopifyOrder.cs
+++ b/src/ShopifyAccess/Models/Order/ShopifyOrder.cs
@@ -44,25 +44,17 @@ namespace ShopifyAccess.Models.Order
 
 		[ DataMember( Name = "fulfillment_status" ) ]
 		private string RawFulfillmentStatus { get; set; }
-		
+
 		[ JsonIgnore ]
 		public FulfillmentStatusEnum FulfillmentStatus
 		{
 			get
 			{
-				if ( Enum.TryParse< FulfillmentStatusEnum >( RawFulfillmentStatus, out var fulfillmentStatus ) )
-				{
+				if( Enum.TryParse< FulfillmentStatusEnum >( this.RawFulfillmentStatus, true, out var fulfillmentStatus ) )
 					return fulfillmentStatus;
-				}
-				else
-				{
-					return FulfillmentStatusEnum.Undefined;
-				}
+				return FulfillmentStatusEnum.Undefined;
 			}
-			set
-			{
-				RawFulfillmentStatus = value.ToString();
-			}
+			set => this.RawFulfillmentStatus = value.ToString();
 		}
 
 		[ DataMember( Name = "source_name" ) ]
@@ -73,19 +65,11 @@ namespace ShopifyAccess.Models.Order
 		{
 			get
 			{
-				if ( Enum.TryParse< ShopifySourceNameEnum >( RawSourceName, out var sourceName ) )
-				{
+				if( Enum.TryParse< ShopifySourceNameEnum >( this.RawSourceName, true, out var sourceName ) )
 					return sourceName;
-				}
-				else
-				{
-					return ShopifySourceNameEnum.Undefined;
-				}
+				return ShopifySourceNameEnum.Undefined;
 			}
-			set
-			{
-				RawSourceName = value.ToString();
-			}
+			set => this.RawSourceName = value.ToString();
 		}
 
 		[ DataMember( Name = "location_id" ) ]

--- a/src/ShopifyAccessTests/ShopifyAccessTests/Orders/Models/ShopifyOrderTests.cs
+++ b/src/ShopifyAccessTests/ShopifyAccessTests/Orders/Models/ShopifyOrderTests.cs
@@ -1,0 +1,129 @@
+using FluentAssertions;
+using NUnit.Framework;
+using ServiceStack.Text;
+using ShopifyAccess.Models.Order;
+
+namespace ShopifyAccessTests.Orders.Models
+{
+	[ TestFixture ]
+	public class ShopifyOrderTests
+	{
+		[ TestCase( "" ) ]
+		[ TestCase( null ) ]
+		[ TestCase( "Undefined" ) ]
+		[ TestCase( "undefined" ) ]
+		[ TestCase( "strange_status" ) ]
+		public void Deserialize_ReturnsUndefinedFulfillmentStatus( string rawFulfillmentStatus )
+		{
+			// Arrange
+			var json = "{\"id\":0,\"total_price\":0,\"created_at\":\"\\/Date(-62135596800000-0000)\\/\",\"order_number\":0,\"financial_status\":\"Undefined\",\"fulfillment_status\":\"" + rawFulfillmentStatus + "\",\"source_name\":\"web\"}";
+
+			// Act
+			var shopifyOrder = JsonSerializer.DeserializeFromString< ShopifyOrder >( json );
+
+			// Assert
+			shopifyOrder.FulfillmentStatus.Should().Be( FulfillmentStatusEnum.Undefined );
+		}
+
+		[ TestCase( "Fulfilled" ) ]
+		[ TestCase( "fulfilled" ) ]
+		public void Deserialize_ReturnsFulfilledFulfillmentStatus( string rawFulfillmentStatus )
+		{
+			// Arrange
+			var json = "{\"id\":0,\"total_price\":0,\"created_at\":\"\\/Date(-62135596800000-0000)\\/\",\"order_number\":0,\"financial_status\":\"Undefined\",\"fulfillment_status\":\"" + rawFulfillmentStatus + "\",\"source_name\":\"web\"}";
+
+			// Act
+			var shopifyOrder = JsonSerializer.DeserializeFromString< ShopifyOrder >( json );
+
+			// Assert
+			shopifyOrder.FulfillmentStatus.Should().Be( FulfillmentStatusEnum.fulfilled );
+		}
+
+		[ TestCase( "Partial" ) ]
+		[ TestCase( "partial" ) ]
+		public void Deserialize_ReturnsPartialFulfillmentStatus( string rawFulfillmentStatus )
+		{
+			// Arrange
+			var json = "{\"id\":0,\"total_price\":0,\"created_at\":\"\\/Date(-62135596800000-0000)\\/\",\"order_number\":0,\"financial_status\":\"Undefined\",\"fulfillment_status\":\"" + rawFulfillmentStatus + "\",\"source_name\":\"web\"}";
+
+			// Act
+			var shopifyOrder = JsonSerializer.DeserializeFromString< ShopifyOrder >( json );
+
+			// Assert
+			shopifyOrder.FulfillmentStatus.Should().Be( FulfillmentStatusEnum.partial );
+		}
+
+		[ TestCase( "" ) ]
+		[ TestCase( null ) ]
+		[ TestCase( "Undefined" ) ]
+		[ TestCase( "undefined" ) ]
+		[ TestCase( "strange_status" ) ]
+		public void Deserialize_ReturnsUndefinedSourceName( string rawSourceName )
+		{
+			// Arrange
+			var json = "{\"id\":0,\"total_price\":0,\"created_at\":\"\\/Date(-62135596800000-0000)\\/\",\"order_number\":0,\"financial_status\":\"Undefined\",\"fulfillment_status\":\"\",\"source_name\":\"" + rawSourceName + "\"}";
+
+			// Act
+			var shopifyOrder = JsonSerializer.DeserializeFromString< ShopifyOrder >( json );
+
+			// Assert
+			shopifyOrder.SourceName.Should().Be( ShopifySourceNameEnum.Undefined );
+		}
+
+		[ TestCase( "Web" ) ]
+		[ TestCase( "web" ) ]
+		public void Deserialize_ReturnsWebSourceName( string rawSourceName )
+		{
+			// Arrange
+			var json = "{\"id\":0,\"total_price\":0,\"created_at\":\"\\/Date(-62135596800000-0000)\\/\",\"order_number\":0,\"financial_status\":\"Undefined\",\"fulfillment_status\":\"\",\"source_name\":\"" + rawSourceName + "\"}";
+
+			// Act
+			var shopifyOrder = JsonSerializer.DeserializeFromString< ShopifyOrder >( json );
+
+			// Assert
+			shopifyOrder.SourceName.Should().Be( ShopifySourceNameEnum.web );
+		}
+
+		[ TestCase( "Pos" ) ]
+		[ TestCase( "pos" ) ]
+		public void Deserialize_ReturnsPosSourceName( string rawSourceName )
+		{
+			// Arrange
+			var json = "{\"id\":0,\"total_price\":0,\"created_at\":\"\\/Date(-62135596800000-0000)\\/\",\"order_number\":0,\"financial_status\":\"Undefined\",\"fulfillment_status\":\"\",\"source_name\":\"" + rawSourceName + "\"}";
+
+			// Act
+			var shopifyOrder = JsonSerializer.DeserializeFromString< ShopifyOrder >( json );
+
+			// Assert
+			shopifyOrder.SourceName.Should().Be( ShopifySourceNameEnum.pos );
+		}
+
+		[ TestCase( "IPhone" ) ]
+		[ TestCase( "iphone" ) ]
+		public void Deserialize_ReturnsIPhoneSourceName( string rawSourceName )
+		{
+			// Arrange
+			var json = "{\"id\":0,\"total_price\":0,\"created_at\":\"\\/Date(-62135596800000-0000)\\/\",\"order_number\":0,\"financial_status\":\"Undefined\",\"fulfillment_status\":\"\",\"source_name\":\"" + rawSourceName + "\"}";
+
+			// Act
+			var shopifyOrder = JsonSerializer.DeserializeFromString< ShopifyOrder >( json );
+
+			// Assert
+			shopifyOrder.SourceName.Should().Be( ShopifySourceNameEnum.iphone );
+		}
+
+		[ TestCase( "Android" ) ]
+		[ TestCase( "android" ) ]
+		public void Deserialize_ReturnsAndroidSourceName( string rawSourceName )
+		{
+			// Arrange
+			var json = "{\"id\":0,\"total_price\":0,\"created_at\":\"\\/Date(-62135596800000-0000)\\/\",\"order_number\":0,\"financial_status\":\"Undefined\",\"fulfillment_status\":\"\",\"source_name\":\"" + rawSourceName + "\"}";
+
+			// Act
+			var shopifyOrder = JsonSerializer.DeserializeFromString< ShopifyOrder >( json );
+
+			// Assert
+			shopifyOrder.SourceName.Should().Be( ShopifySourceNameEnum.android );
+		}
+	}
+}

--- a/src/ShopifyAccessTests/ShopifyAccessTests/Orders/Models/ShopifyOrderTests.cs
+++ b/src/ShopifyAccessTests/ShopifyAccessTests/Orders/Models/ShopifyOrderTests.cs
@@ -9,7 +9,6 @@ namespace ShopifyAccessTests.Orders.Models
 	public class ShopifyOrderTests
 	{
 		[ TestCase( "Fulfilled", FulfillmentStatusEnum.fulfilled ) ]
-		[ TestCase( "Partial", FulfillmentStatusEnum.partial ) ]
 		public void Deserialize_ReturnsFulfillmentStatus_IgnoringCase( string rawFulfillmentStatus, FulfillmentStatusEnum expectedFulfillmentStatus )
 		{
 			// Arrange
@@ -38,9 +37,6 @@ namespace ShopifyAccessTests.Orders.Models
 		}
 
 		[ TestCase( "Web", ShopifySourceNameEnum.web ) ]
-		[ TestCase( "Pos", ShopifySourceNameEnum.pos ) ]
-		[ TestCase( "IPhone", ShopifySourceNameEnum.iphone ) ]
-		[ TestCase( "Android", ShopifySourceNameEnum.android ) ]
 		public void Deserialize_ReturnsSourceName_IgnoringCase( string rawSourceName, ShopifySourceNameEnum expectedSourceName )
 		{
 			// Arrange

--- a/src/ShopifyAccessTests/ShopifyAccessTests/Orders/Models/ShopifyOrderTests.cs
+++ b/src/ShopifyAccessTests/ShopifyAccessTests/Orders/Models/ShopifyOrderTests.cs
@@ -8,15 +8,8 @@ namespace ShopifyAccessTests.Orders.Models
 	[ TestFixture ]
 	public class ShopifyOrderTests
 	{
-		[ TestCase( "", FulfillmentStatusEnum.Undefined ) ]
-		[ TestCase( null, FulfillmentStatusEnum.Undefined ) ]
-		[ TestCase( "Undefined", FulfillmentStatusEnum.Undefined ) ]
-		[ TestCase( "undefined", FulfillmentStatusEnum.Undefined ) ]
-		[ TestCase( "strange_status", FulfillmentStatusEnum.Undefined ) ]
 		[ TestCase( "Fulfilled", FulfillmentStatusEnum.fulfilled ) ]
-		[ TestCase( "fulfilled", FulfillmentStatusEnum.fulfilled ) ]
 		[ TestCase( "Partial", FulfillmentStatusEnum.partial ) ]
-		[ TestCase( "partial", FulfillmentStatusEnum.partial ) ]
 		public void Deserialize_ReturnsFulfillmentStatus_IgnoringCase( string rawFulfillmentStatus, FulfillmentStatusEnum expectedFulfillmentStatus )
 		{
 			// Arrange
@@ -29,20 +22,26 @@ namespace ShopifyAccessTests.Orders.Models
 			shopifyOrder.FulfillmentStatus.Should().Be( expectedFulfillmentStatus );
 		}
 
-		[ TestCase( "", ShopifySourceNameEnum.Undefined ) ]
-		[ TestCase( null, ShopifySourceNameEnum.Undefined ) ]
-		[ TestCase( "Undefined", ShopifySourceNameEnum.Undefined ) ]
-		[ TestCase( "undefined", ShopifySourceNameEnum.Undefined ) ]
-		[ TestCase( "strange_status", ShopifySourceNameEnum.Undefined ) ]
+		[ TestCase( "" ) ]
+		[ TestCase( null ) ]
+		[ TestCase( "strange_status" ) ]
+		public void Deserialize_ReturnsUndefined_WhenFulfillmentStatusIsNotValid( string rawFulfillmentStatus )
+		{
+			// Arrange
+			var json = "{\"id\":0,\"total_price\":0,\"created_at\":\"\\/Date(-62135596800000-0000)\\/\",\"order_number\":0,\"financial_status\":\"Undefined\",\"fulfillment_status\":\"" + rawFulfillmentStatus + "\",\"source_name\":\"web\"}";
+
+			// Act
+			var shopifyOrder = JsonSerializer.DeserializeFromString< ShopifyOrder >( json );
+
+			// Assert
+			shopifyOrder.FulfillmentStatus.Should().Be( FulfillmentStatusEnum.Undefined );
+		}
+
 		[ TestCase( "Web", ShopifySourceNameEnum.web ) ]
-		[ TestCase( "web", ShopifySourceNameEnum.web ) ]
 		[ TestCase( "Pos", ShopifySourceNameEnum.pos ) ]
-		[ TestCase( "pos", ShopifySourceNameEnum.pos ) ]
 		[ TestCase( "IPhone", ShopifySourceNameEnum.iphone ) ]
-		[ TestCase( "iphone", ShopifySourceNameEnum.iphone ) ]
 		[ TestCase( "Android", ShopifySourceNameEnum.android ) ]
-		[ TestCase( "android", ShopifySourceNameEnum.android ) ]
-		public void Deserialize_ReturnsUndefinedSourceName( string rawSourceName, ShopifySourceNameEnum expectedShopifySourceName )
+		public void Deserialize_ReturnsSourceName_IgnoringCase( string rawSourceName, ShopifySourceNameEnum expectedSourceName )
 		{
 			// Arrange
 			var json = "{\"id\":0,\"total_price\":0,\"created_at\":\"\\/Date(-62135596800000-0000)\\/\",\"order_number\":0,\"financial_status\":\"Undefined\",\"fulfillment_status\":\"\",\"source_name\":\"" + rawSourceName + "\"}";
@@ -51,7 +50,22 @@ namespace ShopifyAccessTests.Orders.Models
 			var shopifyOrder = JsonSerializer.DeserializeFromString< ShopifyOrder >( json );
 
 			// Assert
-			shopifyOrder.SourceName.Should().Be( expectedShopifySourceName );
+			shopifyOrder.SourceName.Should().Be( expectedSourceName );
+		}
+
+		[ TestCase( "" ) ]
+		[ TestCase( null ) ]
+		[ TestCase( "strange_status" ) ]
+		public void Deserialize_ReturnsUndefined_WhenSourceNameIsNotValid( string rawSourceName )
+		{
+			// Arrange
+			var json = "{\"id\":0,\"total_price\":0,\"created_at\":\"\\/Date(-62135596800000-0000)\\/\",\"order_number\":0,\"financial_status\":\"Undefined\",\"fulfillment_status\":\"\",\"source_name\":\"" + rawSourceName + "\"}";
+
+			// Act
+			var shopifyOrder = JsonSerializer.DeserializeFromString< ShopifyOrder >( json );
+
+			// Assert
+			shopifyOrder.SourceName.Should().Be( ShopifySourceNameEnum.Undefined );
 		}
 	}
 }

--- a/src/ShopifyAccessTests/ShopifyAccessTests/Orders/Models/ShopifyOrderTests.cs
+++ b/src/ShopifyAccessTests/ShopifyAccessTests/Orders/Models/ShopifyOrderTests.cs
@@ -8,12 +8,16 @@ namespace ShopifyAccessTests.Orders.Models
 	[ TestFixture ]
 	public class ShopifyOrderTests
 	{
-		[ TestCase( "" ) ]
-		[ TestCase( null ) ]
-		[ TestCase( "Undefined" ) ]
-		[ TestCase( "undefined" ) ]
-		[ TestCase( "strange_status" ) ]
-		public void Deserialize_ReturnsUndefinedFulfillmentStatus( string rawFulfillmentStatus )
+		[ TestCase( "", FulfillmentStatusEnum.Undefined ) ]
+		[ TestCase( null, FulfillmentStatusEnum.Undefined ) ]
+		[ TestCase( "Undefined", FulfillmentStatusEnum.Undefined ) ]
+		[ TestCase( "undefined", FulfillmentStatusEnum.Undefined ) ]
+		[ TestCase( "strange_status", FulfillmentStatusEnum.Undefined ) ]
+		[ TestCase( "Fulfilled", FulfillmentStatusEnum.fulfilled ) ]
+		[ TestCase( "fulfilled", FulfillmentStatusEnum.fulfilled ) ]
+		[ TestCase( "Partial", FulfillmentStatusEnum.partial ) ]
+		[ TestCase( "partial", FulfillmentStatusEnum.partial ) ]
+		public void Deserialize_ReturnsFulfillmentStatus_IgnoringCase( string rawFulfillmentStatus, FulfillmentStatusEnum expectedFulfillmentStatus )
 		{
 			// Arrange
 			var json = "{\"id\":0,\"total_price\":0,\"created_at\":\"\\/Date(-62135596800000-0000)\\/\",\"order_number\":0,\"financial_status\":\"Undefined\",\"fulfillment_status\":\"" + rawFulfillmentStatus + "\",\"source_name\":\"web\"}";
@@ -22,43 +26,23 @@ namespace ShopifyAccessTests.Orders.Models
 			var shopifyOrder = JsonSerializer.DeserializeFromString< ShopifyOrder >( json );
 
 			// Assert
-			shopifyOrder.FulfillmentStatus.Should().Be( FulfillmentStatusEnum.Undefined );
+			shopifyOrder.FulfillmentStatus.Should().Be( expectedFulfillmentStatus );
 		}
 
-		[ TestCase( "Fulfilled" ) ]
-		[ TestCase( "fulfilled" ) ]
-		public void Deserialize_ReturnsFulfilledFulfillmentStatus( string rawFulfillmentStatus )
-		{
-			// Arrange
-			var json = "{\"id\":0,\"total_price\":0,\"created_at\":\"\\/Date(-62135596800000-0000)\\/\",\"order_number\":0,\"financial_status\":\"Undefined\",\"fulfillment_status\":\"" + rawFulfillmentStatus + "\",\"source_name\":\"web\"}";
-
-			// Act
-			var shopifyOrder = JsonSerializer.DeserializeFromString< ShopifyOrder >( json );
-
-			// Assert
-			shopifyOrder.FulfillmentStatus.Should().Be( FulfillmentStatusEnum.fulfilled );
-		}
-
-		[ TestCase( "Partial" ) ]
-		[ TestCase( "partial" ) ]
-		public void Deserialize_ReturnsPartialFulfillmentStatus( string rawFulfillmentStatus )
-		{
-			// Arrange
-			var json = "{\"id\":0,\"total_price\":0,\"created_at\":\"\\/Date(-62135596800000-0000)\\/\",\"order_number\":0,\"financial_status\":\"Undefined\",\"fulfillment_status\":\"" + rawFulfillmentStatus + "\",\"source_name\":\"web\"}";
-
-			// Act
-			var shopifyOrder = JsonSerializer.DeserializeFromString< ShopifyOrder >( json );
-
-			// Assert
-			shopifyOrder.FulfillmentStatus.Should().Be( FulfillmentStatusEnum.partial );
-		}
-
-		[ TestCase( "" ) ]
-		[ TestCase( null ) ]
-		[ TestCase( "Undefined" ) ]
-		[ TestCase( "undefined" ) ]
-		[ TestCase( "strange_status" ) ]
-		public void Deserialize_ReturnsUndefinedSourceName( string rawSourceName )
+		[ TestCase( "", ShopifySourceNameEnum.Undefined ) ]
+		[ TestCase( null, ShopifySourceNameEnum.Undefined ) ]
+		[ TestCase( "Undefined", ShopifySourceNameEnum.Undefined ) ]
+		[ TestCase( "undefined", ShopifySourceNameEnum.Undefined ) ]
+		[ TestCase( "strange_status", ShopifySourceNameEnum.Undefined ) ]
+		[ TestCase( "Web", ShopifySourceNameEnum.web ) ]
+		[ TestCase( "web", ShopifySourceNameEnum.web ) ]
+		[ TestCase( "Pos", ShopifySourceNameEnum.pos ) ]
+		[ TestCase( "pos", ShopifySourceNameEnum.pos ) ]
+		[ TestCase( "IPhone", ShopifySourceNameEnum.iphone ) ]
+		[ TestCase( "iphone", ShopifySourceNameEnum.iphone ) ]
+		[ TestCase( "Android", ShopifySourceNameEnum.android ) ]
+		[ TestCase( "android", ShopifySourceNameEnum.android ) ]
+		public void Deserialize_ReturnsUndefinedSourceName( string rawSourceName, ShopifySourceNameEnum expectedShopifySourceName )
 		{
 			// Arrange
 			var json = "{\"id\":0,\"total_price\":0,\"created_at\":\"\\/Date(-62135596800000-0000)\\/\",\"order_number\":0,\"financial_status\":\"Undefined\",\"fulfillment_status\":\"\",\"source_name\":\"" + rawSourceName + "\"}";
@@ -67,63 +51,7 @@ namespace ShopifyAccessTests.Orders.Models
 			var shopifyOrder = JsonSerializer.DeserializeFromString< ShopifyOrder >( json );
 
 			// Assert
-			shopifyOrder.SourceName.Should().Be( ShopifySourceNameEnum.Undefined );
-		}
-
-		[ TestCase( "Web" ) ]
-		[ TestCase( "web" ) ]
-		public void Deserialize_ReturnsWebSourceName( string rawSourceName )
-		{
-			// Arrange
-			var json = "{\"id\":0,\"total_price\":0,\"created_at\":\"\\/Date(-62135596800000-0000)\\/\",\"order_number\":0,\"financial_status\":\"Undefined\",\"fulfillment_status\":\"\",\"source_name\":\"" + rawSourceName + "\"}";
-
-			// Act
-			var shopifyOrder = JsonSerializer.DeserializeFromString< ShopifyOrder >( json );
-
-			// Assert
-			shopifyOrder.SourceName.Should().Be( ShopifySourceNameEnum.web );
-		}
-
-		[ TestCase( "Pos" ) ]
-		[ TestCase( "pos" ) ]
-		public void Deserialize_ReturnsPosSourceName( string rawSourceName )
-		{
-			// Arrange
-			var json = "{\"id\":0,\"total_price\":0,\"created_at\":\"\\/Date(-62135596800000-0000)\\/\",\"order_number\":0,\"financial_status\":\"Undefined\",\"fulfillment_status\":\"\",\"source_name\":\"" + rawSourceName + "\"}";
-
-			// Act
-			var shopifyOrder = JsonSerializer.DeserializeFromString< ShopifyOrder >( json );
-
-			// Assert
-			shopifyOrder.SourceName.Should().Be( ShopifySourceNameEnum.pos );
-		}
-
-		[ TestCase( "IPhone" ) ]
-		[ TestCase( "iphone" ) ]
-		public void Deserialize_ReturnsIPhoneSourceName( string rawSourceName )
-		{
-			// Arrange
-			var json = "{\"id\":0,\"total_price\":0,\"created_at\":\"\\/Date(-62135596800000-0000)\\/\",\"order_number\":0,\"financial_status\":\"Undefined\",\"fulfillment_status\":\"\",\"source_name\":\"" + rawSourceName + "\"}";
-
-			// Act
-			var shopifyOrder = JsonSerializer.DeserializeFromString< ShopifyOrder >( json );
-
-			// Assert
-			shopifyOrder.SourceName.Should().Be( ShopifySourceNameEnum.iphone );
-		}
-
-		[ TestCase( "Android" ) ]
-		[ TestCase( "android" ) ]
-		public void Deserialize_ReturnsAndroidSourceName( string rawSourceName )
-		{
-			// Arrange
-			var json = "{\"id\":0,\"total_price\":0,\"created_at\":\"\\/Date(-62135596800000-0000)\\/\",\"order_number\":0,\"financial_status\":\"Undefined\",\"fulfillment_status\":\"\",\"source_name\":\"" + rawSourceName + "\"}";
-
-			// Act
-			var shopifyOrder = JsonSerializer.DeserializeFromString< ShopifyOrder >( json );
-
-			// Assert
-			shopifyOrder.SourceName.Should().Be( ShopifySourceNameEnum.android );
+			shopifyOrder.SourceName.Should().Be( expectedShopifySourceName );
 		}
 	}
 }

--- a/src/ShopifyAccessTests/ShopifyAccessTests/ShopifyAccessTests.csproj
+++ b/src/ShopifyAccessTests/ShopifyAccessTests/ShopifyAccessTests.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Misc\ActionPoliciesTests.cs" />
     <Compile Include="Misc\LoggerExtensionsTests.cs" />
     <Compile Include="OperationTimeoutTests.cs" />
+    <Compile Include="Orders\Models\ShopifyOrderTests.cs" />
     <Compile Include="Orders\OrderMapperTests.cs" />
     <Compile Include="Orders\OrdersListTests.cs" />
     <Compile Include="Products\Models\ShopifyProductVariantTests.cs" />


### PR DESCRIPTION
# Description

Tickets: [VT-6137]

We can have wrong parse for fields because values can be different cases

- Added ignore case for some fields of ShopifyOrder model
- Added tests

# PR Readiness Checklist

- [X] I have updated all relevant configuration
- [X] Followed [development conventions][1] to the best of my ability
- [X] Code is documented, particularly public interfaces and hard-to-understand areas
- [X] Tests are updated / added and all pass
- [X] Performed a self-review of my own code
- [X] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
- [X] Confluence documentation is updated, if needed
- [X] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions


[VT-6137]: https://agileharbor.atlassian.net/browse/VT-6137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ