### PR TITLE
Temporarily disable LogGetResponse

### DIFF
--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -22,4 +22,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[ assembly : AssemblyVersion( "1.9.1.0" ) ]
+[ assembly : AssemblyVersion( "1.10.0.0" ) ]

--- a/src/ShopifyAccess/Misc/ShopifyLogger.cs
+++ b/src/ShopifyAccess/Misc/ShopifyLogger.cs
@@ -61,9 +61,10 @@ namespace ShopifyAccess.Misc
 		/// <typeparam name="TResponseType">The type of object returned in response from Shopify. Needed to transform the response for logging</typeparam>
 		public static void LogGetResponse< TResponseType >( Uri requestUri, string limit, string jsonResponse, Mark mark, int timeout )
 		{
-			var contentForLogs = jsonResponse.ToLogContents< TResponseType >();
-			Trace( mark, "GET response\tRequest: {0} with timeout {1}ms\tLimit: {2}\tResponse: {3}", 
-				requestUri, timeout, limit, contentForLogs );
+			//Temporarily disabled due to Production issues
+			// var contentForLogs = jsonResponse.ToLogContents< TResponseType >();
+			// Trace( mark, "GET response\tRequest: {0} with timeout {1}ms\tLimit: {2}\tResponse: {3}", 
+			// 	requestUri, timeout, limit, contentForLogs );
 		}
 
 		/// <summary>
@@ -79,10 +80,11 @@ namespace ShopifyAccess.Misc
 		public static void LogGetResponse< TResponseType >( Uri requestUri, string limit, string nextPage, string jsonResponse, 
 			Mark mark, int timeout)
 		{
-			jsonResponse = MaskPersonalInfoInShopifyOrders< TResponseType >( jsonResponse );
-			var contentForLogs = jsonResponse.ToLogContents< TResponseType >();
-			Trace( mark, "GET response\tRequest: {0} with timeout {1}ms\tLimit: {2}\tNext Page: {3}\tResponse: {4}", 
-				requestUri, timeout, limit, nextPage, contentForLogs );
+			//Temporarily disabled due to Production issues
+			// jsonResponse = MaskPersonalInfoInShopifyOrders< TResponseType >( jsonResponse );
+			// var contentForLogs = jsonResponse.ToLogContents< TResponseType >();
+			// Trace( mark, "GET response\tRequest: {0} with timeout {1}ms\tLimit: {2}\tNext Page: {3}\tResponse: {4}", 
+			// 	requestUri, timeout, limit, nextPage, contentForLogs );
 		}
 
 		public static void LogUpdateRequest( Uri requestUri, string jsonContent, Mark mark, int timeout )


### PR DESCRIPTION
Summary: Temporarily disable LogGetResponse

#### Background
[Slav suggested to do this](https://linnworks.slack.com/archives/C05P96HMZLG/p1697119855363429?thread_ts=1697114259.901239&cid=C05P96HMZLG), to potentially resolve a Production issue. This might be causing infinite recursion and overflow.

### PR Readiness Checklist

<!-- Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it. -->

- [ ] I have updated all relevant configuration
- [x] Followed [development conventions][1] to the best of my ability
- [x] Code is documented, particularly public interfaces and hard-to-understand areas
- [ ] Tests are updated / added and all pass
- [x] Performed a self-review of my own code
- [x] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [ ] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions
