### PR TITLE
GUARD-3162 Revert "Temporarily disable LogGetResponse (#36)"

### DIFF
--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -22,4 +22,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[ assembly : AssemblyVersion( "1.10.0.0" ) ]
+[ assembly : AssemblyVersion( "1.9.1.0" ) ]

--- a/src/ShopifyAccess/Misc/ShopifyLogger.cs
+++ b/src/ShopifyAccess/Misc/ShopifyLogger.cs
@@ -61,10 +61,9 @@ namespace ShopifyAccess.Misc
 		/// <typeparam name="TResponseType">The type of object returned in response from Shopify. Needed to transform the response for logging</typeparam>
 		public static void LogGetResponse< TResponseType >( Uri requestUri, string limit, string jsonResponse, Mark mark, int timeout )
 		{
-			//Temporarily disabled due to Production issues
-			// var contentForLogs = jsonResponse.ToLogContents< TResponseType >();
-			// Trace( mark, "GET response\tRequest: {0} with timeout {1}ms\tLimit: {2}\tResponse: {3}", 
-			// 	requestUri, timeout, limit, contentForLogs );
+			var contentForLogs = jsonResponse.ToLogContents< TResponseType >();
+			Trace( mark, "GET response\tRequest: {0} with timeout {1}ms\tLimit: {2}\tResponse: {3}", 
+				requestUri, timeout, limit, contentForLogs );
 		}
 
 		/// <summary>
@@ -80,11 +79,10 @@ namespace ShopifyAccess.Misc
 		public static void LogGetResponse< TResponseType >( Uri requestUri, string limit, string nextPage, string jsonResponse, 
 			Mark mark, int timeout)
 		{
-			//Temporarily disabled due to Production issues
-			// jsonResponse = MaskPersonalInfoInShopifyOrders< TResponseType >( jsonResponse );
-			// var contentForLogs = jsonResponse.ToLogContents< TResponseType >();
-			// Trace( mark, "GET response\tRequest: {0} with timeout {1}ms\tLimit: {2}\tNext Page: {3}\tResponse: {4}", 
-			// 	requestUri, timeout, limit, nextPage, contentForLogs );
+			jsonResponse = MaskPersonalInfoInShopifyOrders< TResponseType >( jsonResponse );
+			var contentForLogs = jsonResponse.ToLogContents< TResponseType >();
+			Trace( mark, "GET response\tRequest: {0} with timeout {1}ms\tLimit: {2}\tNext Page: {3}\tResponse: {4}", 
+				requestUri, timeout, limit, nextPage, contentForLogs );
 		}
 
 		public static void LogUpdateRequest( Uri requestUri, string jsonContent, Mark mark, int timeout )


### PR DESCRIPTION
[GUARD-3162]

#### About these changes
Per [Slack discussion](https://linnworks.slack.com/archives/C05P96HMZLG/p1697558931348419?thread_ts=1697556636.287339&cid=C05P96HMZLG), reverting this since it's not needed and will not be released. Added a note about it to https://github.com/skuvault-integrations/shopifyAccess/releases/tag/1.10.0.

# PR Readiness Checklist

<!-- Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it. -->

- [x] I have updated all relevant configuration
- [x] Followed [development conventions][1] to the best of my ability
- [x] Code is documented, particularly public interfaces and hard-to-understand areas
- [ ] Tests are updated / added and all pass
- [x] Performed a self-review of my own code
- [ ] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [x] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions


[GUARD-3162]: https://agileharbor.atlassian.net/browse/GUARD-3162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ