### PR TITLE
GUARD-3342 Update Shopify version to v2023-10

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -76,7 +76,7 @@ task NuGet Package, Version, {
 <package>
 	<metadata>
 		<id>$project_name</id>
-		<version>$Version</version>
+		<version>$Version-alpha</version>
 		<authors>SkuVault</authors>
 		<owners>SkuVault</owners>
 		<projectUrl>https://github.com/agileharbor/$project_name</projectUrl>

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -22,4 +22,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[ assembly : AssemblyVersion( "1.11.0.0" ) ]
+[ assembly : AssemblyVersion( "1.12.0.0" ) ]

--- a/src/ShopifyAccess/Models/Configuration/Command/ShopifyApiVersion.cs
+++ b/src/ShopifyAccess/Models/Configuration/Command/ShopifyApiVersion.cs
@@ -8,9 +8,9 @@ namespace ShopifyAccess.Models.Configuration.Command
 	public sealed class ShopifyApiVersion
 	{
 		private readonly string _versionCode;
-
-		public static readonly ShopifyApiVersion V2023_01 = new ShopifyApiVersion( "2023-01" );
+		
 		public static readonly ShopifyApiVersion V2023_04 = new ShopifyApiVersion( "2023-04" );
+		public static readonly ShopifyApiVersion V2023_10 = new ShopifyApiVersion( "2023-10" );
 
 		private ShopifyApiVersion( string versionCode )
 		{

--- a/src/ShopifyAccessTests/ShopifyAccessTests/BaseTests.cs
+++ b/src/ShopifyAccessTests/ShopifyAccessTests/BaseTests.cs
@@ -11,7 +11,7 @@ namespace ShopifyAccessTests
 {
 	public class BaseTests
 	{
-		protected static readonly ShopifyApiVersion ApiVersion = ShopifyApiVersion.V2023_04;
+		protected static readonly ShopifyApiVersion ApiVersion = ShopifyApiVersion.V2023_10;
 		protected readonly IShopifyFactory ShopifyFactory = new ShopifyFactory( ApiVersion );
 		protected ShopifyClientCredentials _clientCredentials;
 		protected IShopifyService Service;


### PR DESCRIPTION
# Description

Tickets: [GUARD-3342] <!-- Replace with appropriate tickets. Some automation depend on this section, don't remove -->

Summary: Update Shopify version to v2023-10

## About these changes

Reviewed breaking changes from [2023-10](https://shopify.dev/docs/api/release-notes/2023-10) and [2023-07](https://shopify.dev/docs/api/release-notes/2023-07) and they should not have impact on our code.
All tests passed, except for two related to Users, which are expected to fail according to [this comment](https://github.com/skuvault-integrations/shopifyAccess/blob/d5ac6fecc1488cb2f1aec3304c78ab9b6188049c/src/ShopifyAccessTests/ShopifyAccessTests/Users/UsersTests.cs#L8).

![image](https://github.com/skuvault-integrations/shopifyAccess/assets/103965678/3138d35c-6c40-4d67-9e84-8186af8c2b51)


- Update Shopify version to v2023-10
- Removed version v2023-01
- Updated NuGet package version

# PR Readiness Checklist

<!-- Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it. -->

- [X] I have updated all relevant configuration
- [X] Followed [development conventions][1] to the best of my ability
- [X] Code is documented, particularly public interfaces and hard-to-understand areas
- [X] Tests are updated / added and all pass
- [X] Performed a self-review of my own code
- [X] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [X] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions


[GUARD-3342]: https://agileharbor.atlassian.net/browse/GUARD-3342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ