### PR TITLE
GUARD-3710 Use Shopify API Version 2024-04

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -76,7 +76,7 @@ task NuGet Package, Version, {
 <package>
 	<metadata>
 		<id>$project_name</id>
-		<version>$Version</version>
+		<version>$Version-alpha</version>
 		<authors>SkuVault</authors>
 		<owners>SkuVault</owners>
 		<projectUrl>https://github.com/agileharbor/$project_name</projectUrl>

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ _TeamCity*/
 *.ReSharper
 *.docstates
 _rltm*
-ShopifyCredentials.csv
+*Credentials*.csv
 license.txt
 
 #Ignore common build files

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -22,4 +22,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[ assembly : AssemblyVersion( "1.14.0.0" ) ]
+[ assembly : AssemblyVersion( "1.14.1.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 [ assembly : ComVisible( false ) ]
 [ assembly : AssemblyProduct( "ShopifyAccess" ) ]
 [ assembly : AssemblyCompany( "SkuVault Inc." ) ]
-[ assembly : AssemblyCopyright( "Copyright (C) 2020 SkuVault Inc." ) ]
+[ assembly : AssemblyCopyright( "Copyright (C) 2025 SkuVault Inc." ) ]
 [ assembly : AssemblyDescription( "Shopify webservices API wrapper." ) ]
 [ assembly : AssemblyTrademark( "" ) ]
 [ assembly : AssemblyCulture( "" ) ]
@@ -22,4 +22,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[ assembly : AssemblyVersion( "1.13.0.0" ) ]
+[ assembly : AssemblyVersion( "1.14.0.0" ) ]

--- a/src/ShopifyAccess/Models/Configuration/Command/ShopifyApiVersion.cs
+++ b/src/ShopifyAccess/Models/Configuration/Command/ShopifyApiVersion.cs
@@ -9,8 +9,8 @@ namespace ShopifyAccess.Models.Configuration.Command
 	{
 		private readonly string _versionCode;
 		
-		public static readonly ShopifyApiVersion V2023_04 = new ShopifyApiVersion( "2023-04" );
 		public static readonly ShopifyApiVersion V2023_10 = new ShopifyApiVersion( "2023-10" );
+		public static readonly ShopifyApiVersion V2024_04 = new ShopifyApiVersion( "2024-04" );
 
 		private ShopifyApiVersion( string versionCode )
 		{

--- a/src/ShopifyAccessTests/ShopifyAccessTests/BaseTests.cs
+++ b/src/ShopifyAccessTests/ShopifyAccessTests/BaseTests.cs
@@ -11,7 +11,7 @@ namespace ShopifyAccessTests
 {
 	public class BaseTests
 	{
-		protected static readonly ShopifyApiVersion ApiVersion = ShopifyApiVersion.V2023_10;
+		protected static readonly ShopifyApiVersion ApiVersion = ShopifyApiVersion.V2024_04;
 		protected readonly IShopifyFactory ShopifyFactory = new ShopifyFactory( ApiVersion );
 		protected ShopifyClientCredentials _clientCredentials;
 		protected IShopifyService Service;


### PR DESCRIPTION
[GUARD-3710]

Summary: Explicitly call the Shopify API Version 2024-04 (available through March 2025).

#### Background
Quarterly versions get deprecated one year after release. In production we request version "2023-10" which has been deprecated. Shopify instead uses the oldest supported version "2024-01".

#### About these changes
- Added version 2024-04 to the enum and test. Kept the old version so that other v1 branches that point to this NuGet version aren't broken.

### PR Readiness Checklist

<!-- Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it. -->

- [x] I have updated all relevant configuration
- [x] Followed [development conventions][1] to the best of my ability
- [x] Code is documented, particularly public interfaces and hard-to-understand areas
- [x] Tests are updated / added and all pass
- [x] Performed a self-review of my own code
- [x] Acceptance criteria are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [x] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions


[GUARD-3710]: https://linnworks.atlassian.net/browse/GUARD-3710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ