### PR TITLE
GUARD-3789 GUARD-3761 Add (read)_locations Authorization Scope, Add new API versions

### DIFF
--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -22,4 +22,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[ assembly : AssemblyVersion( "1.16.0.0" ) ]
+[ assembly : AssemblyVersion( "1.16.1.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -22,4 +22,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[ assembly : AssemblyVersion( "1.15.40.0" ) ]
+[ assembly : AssemblyVersion( "1.16.0.0" ) ]

--- a/src/ShopifyAccess/Models/Configuration/Authorization/ShopifyScopeName.cs
+++ b/src/ShopifyAccess/Models/Configuration/Authorization/ShopifyScopeName.cs
@@ -1,5 +1,9 @@
 ﻿namespace ShopifyAccess.Models.Configuration.Authorization
 {
+	/// <summary>
+	/// Authorization scopes our syncs need. NOTE: In v1 we pre-pend "read" or "write" at the beginning. For example, "read_products".
+	/// All scopes - <see href="https://shopify.dev/docs/api/admin-rest/usage/access-scopes"/>
+	/// </summary>
 	public class ShopifyScopeName
 	{
 		public static readonly ShopifyScopeName Content = new ShopifyScopeName( "_content" );

--- a/src/ShopifyAccess/Models/Configuration/Authorization/ShopifyScopeName.cs
+++ b/src/ShopifyAccess/Models/Configuration/Authorization/ShopifyScopeName.cs
@@ -12,6 +12,7 @@
 		public static readonly ShopifyScopeName Shipping = new ShopifyScopeName( "_shipping" );
 		public static readonly ShopifyScopeName Inventory = new ShopifyScopeName( "_inventory" );
 		public static readonly ShopifyScopeName AllOrders = new ShopifyScopeName( "_all_orders" );
+		public static readonly ShopifyScopeName Locations = new ShopifyScopeName( "_locations" );
 		
 		private ShopifyScopeName( string name )
 		{

--- a/src/ShopifyAccess/Models/Configuration/Command/ShopifyApiVersion.cs
+++ b/src/ShopifyAccess/Models/Configuration/Command/ShopifyApiVersion.cs
@@ -9,8 +9,10 @@ namespace ShopifyAccess.Models.Configuration.Command
 	{
 		private readonly string _versionCode;
 		
-		public static readonly ShopifyApiVersion V2023_10 = new ShopifyApiVersion( "2023-10" );
 		public static readonly ShopifyApiVersion V2024_04 = new ShopifyApiVersion( "2024-04" );
+		public static readonly ShopifyApiVersion V2024_07 = new ShopifyApiVersion( "2024-07" );
+		public static readonly ShopifyApiVersion V2024_10 = new ShopifyApiVersion( "2024-10" );
+		public static readonly ShopifyApiVersion V2025_01 = new ShopifyApiVersion( "2025-01" );
 
 		private ShopifyApiVersion( string versionCode )
 		{

--- a/src/ShopifyAccessTests/ShopifyAccessTests/BaseTests.cs
+++ b/src/ShopifyAccessTests/ShopifyAccessTests/BaseTests.cs
@@ -11,7 +11,7 @@ namespace ShopifyAccessTests
 {
 	public class BaseTests
 	{
-		protected static readonly ShopifyApiVersion ApiVersion = ShopifyApiVersion.V2024_04;
+		protected static readonly ShopifyApiVersion ApiVersion = ShopifyApiVersion.V2024_07;
 		protected readonly IShopifyFactory ShopifyFactory = new ShopifyFactory( ApiVersion );
 		protected ShopifyClientCredentials _clientCredentials;
 		protected IShopifyService Service;


### PR DESCRIPTION
[GUARD-3789] [GUARD-3761]
Summary: Add `*_locations` authorization scope, add new API versions & remove deprecated versions

#### Background
There's a [breaking GraphQL change](https://shopify.dev/changelog/the-location-object-requires-read_locations-scope) in Shopify API version 2024-07 we'll be forced to switch to on April 1st.

#### About these changes
- Add `*_locations` scope
- Add all currently supported Shopify API versions, remove deprecated versions
- [Cleanup] Add an XML doc for ShopifyScopeName

### PR Readiness Checklist

<!-- Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it. -->

- [x] I have updated all relevant configuration
- [x] Followed [development conventions][1] to the best of my ability
- [x] Code is documented, particularly public interfaces and hard-to-understand areas
- [x] Tests are updated / added and all pass
- [x] Performed a self-review of my own code
- [ ] Acceptance criteria are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [x] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions


[GUARD-3789]: https://linnworks.atlassian.net/browse/GUARD-3789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GUARD-3761]: https://linnworks.atlassian.net/browse/GUARD-3761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ