### PR TITLE
GUARD-3719 Update tracking info

### DIFF
--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -22,4 +22,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[ assembly : AssemblyVersion( "1.17.1.0" ) ]
+[ assembly : AssemblyVersion( "1.17.2.0" ) ]

--- a/src/ShopifyAccess/GraphQl/Models/Orders/Extensions/OrderExtensions.cs
+++ b/src/ShopifyAccess/GraphQl/Models/Orders/Extensions/OrderExtensions.cs
@@ -64,7 +64,7 @@ namespace ShopifyAccess.GraphQl.Models.Orders.Extensions
 		internal static ShopifyFulfillment ToShopifyFulfillment( this Fulfillment fulfillment, long orderId )
 		{
 			var lineItemDetails = fulfillment.FulfillmentLineItems?.Items?.Select( x => x.LineItem );
-			var trackingInfo = fulfillment.TrackingInfo?.LastOrDefault();
+			var trackingInfo = fulfillment.TrackingInfo?.FirstOrDefault();
 
 			return new ShopifyFulfillment
 			{


### PR DESCRIPTION
# Description

Tickets: [GUARD-3719] <!-- Replace with appropriate tickets. Some automation depend on this section, don't remove -->

Summary: Select the first available tracking info from the list.

## Background

In the current REST calls, there are both list fields (e.g., TrackingNumbers, TrackingURLs) and single fields (e.g., TrackingNumber, TrackingURL) related to the tracking info. When multiple values exist in the list fields, the single fields are populated with the first value from those lists.

## About these changes

Updated tracking info fields to use `.FirstOrDefault()` instead of `.LastOrDefault()`, aligning with Shopify’s current REST implementation.

# PR Readiness Checklist

<!-- Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it. -->

- [X] I have updated all relevant configuration
- [X] Followed [development conventions][1] to the best of my ability
- [X] Code is documented, particularly public interfaces and hard-to-understand areas
- [X] Tests are updated / added and all pass
- [X] Performed a self-review of my own code
- [X] Acceptance criteria are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [X] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions


[GUARD-3719]: https://linnworks.atlassian.net/browse/GUARD-3719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ