### PR TITLE
GUARD-3719 Update Orders query parameters

### DIFF
--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -22,4 +22,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[ assembly : AssemblyVersion( "1.17.2.0" ) ]
+[ assembly : AssemblyVersion( "1.17.3.0" ) ]

--- a/src/ShopifyAccess/GraphQl/Queries/Orders/OrderQueryBuilder.cs
+++ b/src/ShopifyAccess/GraphQl/Queries/Orders/OrderQueryBuilder.cs
@@ -20,7 +20,7 @@ namespace ShopifyAccess.GraphQl.Queries.Orders
 
 			var variables = new
 			{
-				query = $"created_at:>='{dateFromUtc.ToIso8601()}' created_at:<='{dateToUtc.ToIso8601()}' status:'{status}'",
+				query = $"updated_at:>={dateFromUtc.ToIso8601()} updated_at:<={dateToUtc.ToIso8601()} status:{status}",
 				after,
 				first = ordersPerPage
 			};

--- a/src/ShopifyAccess/GraphQl/Queries/Orders/OrderQueryBuilder.cs
+++ b/src/ShopifyAccess/GraphQl/Queries/Orders/OrderQueryBuilder.cs
@@ -20,7 +20,7 @@ namespace ShopifyAccess.GraphQl.Queries.Orders
 
 			var variables = new
 			{
-				query = $"updated_at:>='{dateFromUtc.ToUniversalTime().ToIso8601()}' AND updated_at:<='{dateToUtc.ToUniversalTime().ToIso8601()}' AND status:'{status}'",
+				query = $"updated_at:>='{dateFromUtc.ToIso8601()}' AND updated_at:<='{dateToUtc.ToIso8601()}' AND status:'{status}'",
 				after,
 				first = ordersPerPage
 			};

--- a/src/ShopifyAccess/GraphQl/Queries/Orders/OrderQueryBuilder.cs
+++ b/src/ShopifyAccess/GraphQl/Queries/Orders/OrderQueryBuilder.cs
@@ -20,7 +20,7 @@ namespace ShopifyAccess.GraphQl.Queries.Orders
 
 			var variables = new
 			{
-				query = $"updated_at:>={dateFromUtc.ToIso8601()} updated_at:<={dateToUtc.ToIso8601()} status:{status}",
+				query = $"updated_at:>='{dateFromUtc.ToUniversalTime().ToIso8601()}' AND updated_at:<='{dateToUtc.ToUniversalTime().ToIso8601()}' AND status:'{status}'",
 				after,
 				first = ordersPerPage
 			};

--- a/src/ShopifyAccessTests/ShopifyAccessTests/GraphQl/Queries/Orders/OrderQueryBuilderTests.cs
+++ b/src/ShopifyAccessTests/ShopifyAccessTests/GraphQl/Queries/Orders/OrderQueryBuilderTests.cs
@@ -33,37 +33,5 @@ namespace ShopifyAccessTests.GraphQl.Queries.Orders
 				Assert.That( result.Contains( ordersPerPage.ToString() ), Is.True );
 			} );
 		}
-
-		[ TestCase(
-			"2025-09-17 20:56:05", "2025-09-17 20:59:37",
-			"2025-09-17T20:56:05.0000000Z", "2025-09-17T20:59:37.0000000Z"
-		) ]
-		public void GetOrdersRequest_ShouldIncludeUtcIso8601Dates( string inputFrom, string inputTo, string expectedFrom, string expectedTo )
-		{
-			// Arrange
-			var dateFrom = DateTime.SpecifyKind( DateTime.Parse( inputFrom ), DateTimeKind.Utc );
-			var dateTo = DateTime.SpecifyKind( DateTime.Parse( inputTo ), DateTimeKind.Utc );
-
-			// Act
-			var query = OrderQueryBuilder.GetOrdersRequest(
-				dateFrom,
-				dateTo,
-				status : ShopifyOrderStatus.any.ToString(),
-				after : null,
-				ordersPerPage : 10
-			);
-
-			var formattedFrom = dateFrom.ToIso8601();
-			var formattedTo = dateTo.ToIso8601();
-
-			// Assert
-			Assert.That( formattedFrom, Does.StartWith( expectedFrom ) );
-			Assert.That( formattedFrom, Does.EndWith( "Z" ) );
-			Assert.That( formattedTo, Does.StartWith( expectedTo ) );
-			Assert.That( formattedTo, Does.EndWith( "Z" ) );
-
-			Assert.That( query, Does.Contain( formattedFrom ) );
-			Assert.That( query, Does.Contain( formattedTo ) );
-		}
 	}
 }

--- a/src/ShopifyAccessTests/ShopifyAccessTests/GraphQl/Queries/Orders/OrderQueryBuilderTests.cs
+++ b/src/ShopifyAccessTests/ShopifyAccessTests/GraphQl/Queries/Orders/OrderQueryBuilderTests.cs
@@ -1,6 +1,7 @@
 using System;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
+using ShopifyAccess.GraphQl.Helpers;
 using ShopifyAccess.GraphQl.Queries.Orders;
 using ShopifyAccess.Models.Order;
 
@@ -31,6 +32,38 @@ namespace ShopifyAccessTests.GraphQl.Queries.Orders
 				Assert.That( result.Contains( nextCursor ), Is.True );
 				Assert.That( result.Contains( ordersPerPage.ToString() ), Is.True );
 			} );
+		}
+
+		[ TestCase(
+			"2025-09-17 20:56:05", "2025-09-17 20:59:37",
+			"2025-09-17T20:56:05.0000000Z", "2025-09-17T20:59:37.0000000Z"
+		) ]
+		public void GetOrdersRequest_ShouldIncludeUtcIso8601Dates( string inputFrom, string inputTo, string expectedFrom, string expectedTo )
+		{
+			// Arrange
+			var dateFrom = DateTime.SpecifyKind( DateTime.Parse( inputFrom ), DateTimeKind.Utc );
+			var dateTo = DateTime.SpecifyKind( DateTime.Parse( inputTo ), DateTimeKind.Utc );
+
+			// Act
+			var query = OrderQueryBuilder.GetOrdersRequest(
+				dateFrom,
+				dateTo,
+				status : ShopifyOrderStatus.any.ToString(),
+				after : null,
+				ordersPerPage : 10
+			);
+
+			var formattedFrom = dateFrom.ToIso8601();
+			var formattedTo = dateTo.ToIso8601();
+
+			// Assert
+			Assert.That( formattedFrom, Does.StartWith( expectedFrom ) );
+			Assert.That( formattedFrom, Does.EndWith( "Z" ) );
+			Assert.That( formattedTo, Does.StartWith( expectedTo ) );
+			Assert.That( formattedTo, Does.EndWith( "Z" ) );
+
+			Assert.That( query, Does.Contain( formattedFrom ) );
+			Assert.That( query, Does.Contain( formattedTo ) );
 		}
 	}
 }


### PR DESCRIPTION
# Description

Tickets: [GUARD-3719] <!-- Replace with appropriate tickets. Some automation depend on this section, don't remove -->

Summary: Replace 'created_at' parameters with 'updated_at'

## Background

<!-- In a few sentences provide a description of the problem been resolved. -->

## About these changes

- Changed the query to use `updated_at` date ranges instead of `created_at`, which was mistakenly used before.

# PR Readiness Checklist

<!-- Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it. -->

- [X] I have updated all relevant configuration
- [X] Followed [development conventions][1] to the best of my ability
- [X] Code is documented, particularly public interfaces and hard-to-understand areas
- [X] Tests are updated / added and all pass
- [X] Performed a self-review of my own code
- [X] Acceptance criteria are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [X] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions


[GUARD-3719]: https://linnworks.atlassian.net/browse/GUARD-3719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ